### PR TITLE
fetching new commits for repos can get wonky if people aren't using m…

### DIFF
--- a/packages/github_backup.py
+++ b/packages/github_backup.py
@@ -162,10 +162,11 @@ if __name__ == '__main__':
         else:
             repo_path = h.https_url_with_auth(repo['clone_url'])
         if os.path.exists(destdir):
+            # pull in new commits to an already tracked repository
             print '*** updating %s... ***' % h.redact(repo_path)
             with chdir(destdir):
                 try:
-                    h.exec_cmd('git pull %s' % repo_path)
+                    h.exec_cmd('git pull origin %s' % repo['default_branch'])
                 except Exception as e:
                     print 'error: %s' % e
         else:

--- a/packages/github_backup.py
+++ b/packages/github_backup.py
@@ -41,7 +41,7 @@ class Helpers(object):
         print "Executing command: %s" % self.redact(command)
         resp = os.system(command)
         if resp != 0:
-            raise Exception("Command [%s] failed (%s)" % (command, resp))
+            raise Exception(self.redact("Command [%s] failed (%s)" % (command, resp)))
 
     def https_url_with_auth(self, base_url):
         _, suffix = base_url.split('https://')


### PR DESCRIPTION
…aster as the default branch and we pull this way. In some cases it seems to try to do a merge.

It looks like once this happens, we can't pull successfully anymore by specifying the repository URL instead of just `git pull origin <DEFAULT-BRANCH-NAME>`

I see things like:
```
error: Command [git pull https://sprout-machine:REDACTED@github.com/sproutsocial/bloom-mobile.git] failed (256)
```

Then:
```
Pull is not possible because you have unmerged files.
```

The commits in bloom-mobile are also very stale.

I'm not 100% confident in this hypothesis, but it's worth a try. I'm hesitant to change how `github_backup.py` is shelling out to execute git commands to dig in further, purely because handling subprocesses in Python can be a little annoying.

Here's hoping.

** I also plugged a security issue, we were logging the github password being used when printing the exception traces.
