### PR TITLE
Switch nginx base to version that fixes permissions; make uwsgi not single threaded

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ RUN groupadd -r botanist -g 9009 && useradd -u 9009 -g 9009 --no-log-init -r -g 
 RUN chown -R botanist:botanist ${r}
 USER botanist
 
-CMD uwsgi --socket :9090 --chdir /code --wsgi-file /code/codesearch/wsgi.py
+CMD uwsgi --socket :9090 --chdir /code --wsgi-file /code/codesearch/wsgi.py --master --processes 4 --threads 2

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -7,7 +7,7 @@ RUN /code/manage.py collectstatic --noinput
 
 # multistage builds are awesomeeee
 # https://docs.docker.com/engine/userguide/eng-image/multistage-build/#use-multi-stage-builds
-FROM stantonk/nginx-ldap:1.0.0
+FROM stantonk/nginx-ldap:1.0.1
 
 # for envsubst
 RUN apt-get update && apt-get install -y gettext

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -7,10 +7,7 @@ RUN /code/manage.py collectstatic --noinput
 
 # multistage builds are awesomeeee
 # https://docs.docker.com/engine/userguide/eng-image/multistage-build/#use-multi-stage-builds
-# FROM nginx:1.13.5
-# https://github.com/g17/nginx-ldap
-#TODO: vendor/pull in the source of this container in case it gets deleted like the last one :(
-FROM horalstvo/nginx-ldap
+FROM stantonk/nginx-ldap:1.0.0
 
 # for envsubst
 RUN apt-get update && apt-get install -y gettext

--- a/etc/nginx/nginx.conf.template
+++ b/etc/nginx/nginx.conf.template
@@ -52,10 +52,8 @@ http {
          auth_ldap_servers ldapserver;
          uwsgi_pass django;
          include /etc/nginx/uwsgi_params;
-         # wait up to 3 minutes instead of the 1 minute default
-         # sometimes you just need to search for something obscure in our code :)
          # http://nginx.org/en/docs/http/ngx_http_uwsgi_module.html#uwsgi_read_timeout
-         uwsgi_read_timeout 180s;
+         uwsgi_read_timeout 60s;
       }
 
       access_log /var/log/nginx/access.log;

--- a/etc/nginx/nginx.conf.template
+++ b/etc/nginx/nginx.conf.template
@@ -52,6 +52,10 @@ http {
          auth_ldap_servers ldapserver;
          uwsgi_pass django;
          include /etc/nginx/uwsgi_params;
+         # wait up to 3 minutes instead of the 1 minute default
+         # sometimes you just need to search for something obscure in our code :)
+         # http://nginx.org/en/docs/http/ngx_http_uwsgi_module.html#uwsgi_read_timeout
+         uwsgi_read_timeout 180s;
       }
 
       access_log /var/log/nginx/access.log;

--- a/makefile.docker
+++ b/makefile.docker
@@ -5,11 +5,3 @@ nginx:
 
 botanist:
 	docker build -f Dockerfile -t sproutsocial/botanist .
-
-push-all: push-botanist push-nginx
-
-push-nginx:
-	docker push sproutsocial/botanist-nginx:latest
-
-push-botanist:
-	docker push sproutsocial/botanist:latest


### PR DESCRIPTION
see:

https://github.com/horalstvo/nginx-ldap/pull/1

fixes this error:

```
Sep  8 15:46:50 prod-codesearcher-useast1a-01 botanist-webapp[31793]: INFO 2018-09-08 15:46:50,140 views cmd = /botanist/bin/codesearch-0.01/csearch -n  def
Sep  8 15:47:08 prod-codesearcher-useast1a-01 botanist-webapp[31793]: INFO 2018-09-08 15:47:08,857 views csearch return code = 1
Sep  8 15:47:25 prod-codesearcher-useast1a-01 botanist-webapp[31793]: INFO 2018-09-08 15:47:25,919 views search time=35.78 seconds
Sep  8 15:47:40 prod-codesearcher-useast1a-01 botanist-nginx[31793]: 172.26.3.123 - kevin [08/Sep/2018:15:47:40 +0000] "GET /search/?q=def&case=sensitive HTTP/1.1" 200 65323 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36"
Sep  8 15:47:40 prod-codesearcher-useast1a-01 botanist-nginx[31793]: 2018/09/08 15:47:40 [crit] 17#17: *39 open() "/var/cache/nginx/uwsgi_temp/3/00/0000000003" failed (13: Permission denied) while reading upstream, client: 172.26.3.123, server: localhost, request: "GET /search/?q=def&case=sensitive HTTP/1.1", upstream: "uwsgi://172.18.0.3:9090", host: "172.26.2.22"
Sep  8 15:47:40 prod-codesearcher-useast1a-01 botanist-webapp[31793]: Sat Sep  8 15:47:40 2018 - uwsgi_response_write_body_do(): Connection reset by peer [core/writer.c line 341] during GET /search/?q=def&case=sensitive (172.26.3.123)
Sep  8 15:47:40 prod-codesearcher-useast1a-01 botanist-webapp[31793]: IOError: write error
Sep  8 15:47:40 prod-codesearcher-useast1a-01 botanist-webapp[31793]: [pid: 6|app: 0|req: 9/9] 172.26.3.123 () {46 vars in 850 bytes} [Sat Sep  8 15:46:50 2018] GET /search/?q=def&case=sensitive => generated 182346 bytes in 50467 msecs (HTTP/1.1 200) 3 headers in 102 bytes (1 switches on core 0)
```