### PR TITLE
redirect http to https

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -18,4 +18,6 @@ ADD ./etc/nginx/nginx.conf.template /etc/nginx/nginx.conf.template
 
 COPY --from=collectstatic /code/botanist-static /data/static
 
-CMD /bin/bash -c "envsubst < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && dockerize -stdout /var/log/nginx/access.log -stderr /var/log/nginx/error.log /usr/sbin/nginx -g 'daemon off;'"
+# enumrate env vars we allow envsubst to operate on so nginx variables
+# such as $host and $request_uri don't get replaced :)
+CMD /bin/bash -c "envsubst '\$NGINX_HOST \$NGINX_PORT \$LDAP_URL \$LDAP_BIND_DN \$LDAP_BIND_DN_PASSWD \$LDAP_GROUP_ATTRIBUTE \$LDAP_GROUP_ATTRIBUTE_IS_DN \$LDAP_REQUIRE_GROUP'< /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && dockerize -stdout /var/log/nginx/access.log -stderr /var/log/nginx/error.log /usr/sbin/nginx -g 'daemon off;'"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       env_file:
         - ./env.local
       ports:
+         - 80:80
          - 443:443
       volumes:
          # IMPORTANT: do not use these snake-oil certs in production!

--- a/etc/nginx/nginx.conf.template
+++ b/etc/nginx/nginx.conf.template
@@ -28,11 +28,16 @@ http {
    }
 
    server {
-      listen 443;
+      listen 80 default_server;
+      server_name localhost;
+      return 301 https://$host$request_uri;
+   }
+
+   server {
+      listen 443 ssl default_server;
       server_name localhost;
       charset utf-8;
 
-      ssl on;
       # hardcoded cert/key paths because we assume
       # the proper certs will be mounted into the container
       # at /etc/ssl/nginx


### PR DESCRIPTION
woot

```
$  cp env.template env.local && docker-compose down && docker-compose build && docker-compose up -d

...
```

```
$  curl -vs "http://localhost"
* Rebuilt URL to: http://localhost/
*   Trying ::1...
* TCP_NODELAY set
* Connection failed
* connect to ::1 port 80 failed: Connection refused
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 80 (#0)
> GET / HTTP/1.1
> Host: localhost
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.10.2
< Date: Wed, 12 Sep 2018 03:32:58 GMT
< Content-Type: text/html
< Content-Length: 185
< Connection: keep-alive
< Location: https://localhost/
<
<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/1.10.2</center>
</body>
</html>
* Connection #0 to host localhost left intact
```
