### PR TITLE
Allow hosts

### DIFF
--- a/webapp/codesearch/settings.py
+++ b/webapp/codesearch/settings.py
@@ -24,7 +24,7 @@ SECRET_KEY = '(t_@2%*#-r)ia2&v-owr@5z9dg_7t45!gtommzones-k%uac%$'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['codesearcher.int.sproutsocial.com', 'localhost']
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition

--- a/webapp/codesearch/settings.py
+++ b/webapp/codesearch/settings.py
@@ -24,7 +24,7 @@ SECRET_KEY = '(t_@2%*#-r)ia2&v-owr@5z9dg_7t45!gtommzones-k%uac%$'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['codesearcher.int.sproutsocial.com', 'localhost']
 
 
 # Application definition


### PR DESCRIPTION
New django versions require `ALLOWED_HOSTS` to be explicitly set. The app runs locally via `./manage.py runserver`. 

<img width="1212" alt="Screen Shot 2019-03-13 at 3 34 08 PM" src="https://user-images.githubusercontent.com/7722157/54313281-f80d0000-45a6-11e9-8b5b-cada6934f6d7.png">
