### PR TITLE
if git pull origin master fails for any reason, purge the directory and re-clone

### DIFF
--- a/packages/github_backup.py
+++ b/packages/github_backup.py
@@ -158,6 +158,7 @@ if __name__ == '__main__':
         if not args.forks and repo['fork']:
             print 'skipping fork repository %s' % repo['name']
             continue
+
         destdir = os.path.join(args.directory, repo['name'])
         if args.authtype == 'ssh':
             repo_path = repo['ssh_url']
@@ -169,11 +170,13 @@ if __name__ == '__main__':
             with chdir(destdir):
                 try:
                     h.exec_cmd('git pull origin %s' % repo['default_branch'])
+                    continue
                 except Exception as e:
-                    print 'error: %s' % e
-        else:
-            print '*** backing up %s... ***' % h.redact(repo_path)
-            try:
-                h.exec_cmd('git clone %s %s' % (repo_path, destdir))
-            except Exception as e:
-                print 'error: %s' % e
+                    print 'error: %s (repo=%s); will re-clone!' % (e, repo['name'])
+
+        # clone the repo fresh, deleting if it already existed
+        print '*** backing up %s... ***' % h.redact(repo_path)
+        try:
+            h.exec_cmd('rm -rf %s && git clone %s %s' % (destdir, repo_path, destdir))
+        except Exception as e:
+            print 'error: %s' % e


### PR DESCRIPTION
i tested locally by:

1. running `packages/github_backup.py` locally 
2. deleting the `.git` folder inside one of the repos it had fetched so the next `git pull origin master` would fail,
3. rerunning `packages.github_backup.py` again

which effectively simulates the issue and the cron'd periodic operation of the github backup script.

```
*** updating https://REDACTED:REDACTED@github.com/sproutsocial/wordsalad.git... ***
Executing command: git pull origin develop
fatal: not a git repository (or any of the parent directories): .git
error: Command [git pull origin develop] failed (32768)
will have to remove and re-clone wordsalad
*** backing up https://REDACTED:REDACTED@github.com/sproutsocial/wordsalad.git... ***
Executing command: rm -rf /Users/kevin/botanist/repos/github/sproutsocial/wordsalad && git clone https://REDACTED:REDACTED@github.com/sproutsocial/wordsalad.git /Users/kevin/botanist/repos/github/sproutsocial/wordsalad
Cloning into '/Users/kevin/botanist/repos/github/sproutsocial/wordsalad'...
remote: Enumerating objects: 401, done.
remote: Total 401 (delta 0), reused 0 (delta 0), pack-reused 401
Receiving objects: 100% (401/401), 1.35 MiB | 4.91 MiB/s, done.
Resolving deltas: 100% (237/237), done.
```

this should make codesearcher a lot more resilient to weird repo states. the logs suggest the sproutsocial/android, sproutsocial/iOS, and sproutsocial/listening-api repos all were suffering from the same problem as sproutsocial/racine.