### PR TITLE
[EE-680] Allow botanist to pick-up non-master GitHub deeplinks

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -10,7 +10,14 @@ RUN /code/manage.py collectstatic --noinput
 FROM stantonk/nginx-ldap:1.0.1
 
 # for envsubst
-RUN apt-get update && apt-get install -y gettext
+# Note, there's some aggressive stuff we're doing here due to jessie-backports
+# being EOLed. This all links back to stantonk/nginx-ldap which should be updated
+# for a more recent Debian, some related reading:
+#  * https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository/508728#508728
+#  * https://unix.stackexchange.com/questions/2544/how-to-work-around-release-file-expired-problem-on-a-local-mirror
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list && \
+apt-get update -o Acquire::Check-Valid-Until=false && \
+apt-get install -y --force-yes gettext
 
 # from https://raw.githubusercontent.com/nginx/nginx/master/conf/uwsgi_params
 ADD uwsgi_params /etc/nginx/uwsgi_params

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -10,14 +10,7 @@ RUN /code/manage.py collectstatic --noinput
 FROM stantonk/nginx-ldap:1.0.1
 
 # for envsubst
-# Note, there's some aggressive stuff we're doing here due to jessie-backports
-# being EOLed. This all links back to stantonk/nginx-ldap which should be updated
-# for a more recent Debian, some related reading:
-#  * https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository/508728#508728
-#  * https://unix.stackexchange.com/questions/2544/how-to-work-around-release-file-expired-problem-on-a-local-mirror
-RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list && \
-apt-get update -o Acquire::Check-Valid-Until=false && \
-apt-get install -y --force-yes gettext
+RUN apt-get update && apt-get install -y gettext
 
 # from https://raw.githubusercontent.com/nginx/nginx/master/conf/uwsgi_params
 ADD uwsgi_params /etc/nginx/uwsgi_params

--- a/webapp/ui/tests/test_get_repo_and_filepath.py
+++ b/webapp/ui/tests/test_get_repo_and_filepath.py
@@ -91,3 +91,8 @@ class DeepLink(TestMixin, TestCase):
         dl = deep_link(*get_repo_and_filepath(filename), lineno=42)
 
         self.assertEqual('https://github.com/org-name/repositoryname/blob/master/somedir/sourcefile.py#L42', dl)
+
+    def test_deep_link_github_with_main_branch(self):
+        filename = os.path.join(CODE_ROOT, 'github', 'org-name', 'repositoryname', 'somedir', 'sourcefile.py')
+        dl = deep_link(*get_repo_and_filepath(filename), lineno=42, git_branch='main')
+        self.assertEqual('https://github.com/org-name/repositoryname/blob/main/somedir/sourcefile.py#L42', dl)


### PR DESCRIPTION
Two big changes here:

1. ~For building purposes, `stantonk/nginx-ldap:1.0.1` is built from Debian jessie-backports which has been hard EOLed resulting in some weirdness in the associated nginx image in this repo. We'll follow-up with either a move away from this container entirely or an update to `stantonk/nginx-ldap`.~ - Punting on this for right now
2. Deeplinking behavior has been modified to allow overriding the branch from `master`. Note, this has two implications:
  - In a production setting where botanist is already running we'll need to reclone repos, particularly those that aren't actually driven from `master` any longer.
  - Certain repos that already use a multi-branching strategy don't have a `master` as default but because of the way they deeplink were a) pointing at the wrong thing in GitHub and b) now failing if `master` no longer exists. 
