### PR TITLE
TOOLCM-1955 - improve github outage handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
    nginx:
       build:


### PR DESCRIPTION
1. Modifies the backup script to better handle github outages.

Previously in times where github is temporarily not working, the script would completely delete the existing backup directory before attempting a fresh clone. In that case when github is erroring, this meant that the previous backup was deleted, then the new clone failed, leaving no copies at all. After the next index job ran, all repos would no longer be searchable.

This changes the logic such that in the case where there is not an existing backup directory, or the git pull errors, the fresh clone is made to a temporary directory first. Only if the clone succeeds does it then delete the existing directory if it exists, then move the temp copy into place.

I tested a couple scenarios, making the existing cloned directory invalid, and making the git pull and git clone fail, and in both cases it worked correctly by deleting and replacing the broken directory in the first case, and not deleting the working directory in the second case.

2. Fixed the logic for logging when archived repositories were skipped. It was logging every repository as being skipped.

3. Modified the local docker-compose.yml to remove the version attribute which is deprecated now.