### PR TITLE
[TOOLCM-2168] Catch missing link header

### DIFF
--- a/packages/github_backup.py
+++ b/packages/github_backup.py
@@ -102,7 +102,9 @@ def get_repos(org, repo_type, access_token=None, username=None, password=None, p
         raise ValueError('unworkable combination of authentication inputs')
 
     response = urlopen(request)
-    raw_link_header = response.headers.get('Link')
+    # response.headers is an instance of http.client.HTTPMessage,
+    # which returns `None` for missing keys
+    raw_link_header = response.headers['Link']
     if raw_link_header is None:
         logging.debug('no Link header, nothing to paginate through.')
         pagination = Pagination(None, None, None, None)

--- a/packages/github_backup.py
+++ b/packages/github_backup.py
@@ -110,7 +110,8 @@ def get_repos(org, repo_type, access_token=None, username=None, password=None, p
     if raw_link_header is None:
         logging.debug('no Link header, nothing to paginate through.')
         pagination = Pagination(None, None, None, None)
-    pagination = get_pagination(raw_link_header)
+    else:
+        pagination = get_pagination(raw_link_header)
 
     repos = json.loads(response.read())
     for r in repos:

--- a/packages/github_backup.py
+++ b/packages/github_backup.py
@@ -102,8 +102,10 @@ def get_repos(org, repo_type, access_token=None, username=None, password=None, p
         raise ValueError('unworkable combination of authentication inputs')
 
     response = urlopen(request)
-    # response.headers is an instance of http.client.HTTPMessage,
-    # which returns `None` for missing keys
+    # response.headers is an instance of http.client.HTTPMessage, which returns `None`
+    # for missing keys. Refer to email.message.Message.__getitem__ (currently at
+    # https://github.com/python/cpython/blob/3.11/Lib/email/message.py#L410-L419)
+    # for the specific implementation.
     raw_link_header = response.headers['Link']
     if raw_link_header is None:
         logging.debug('no Link header, nothing to paginate through.')

--- a/packages/github_backup.py
+++ b/packages/github_backup.py
@@ -102,11 +102,11 @@ def get_repos(org, repo_type, access_token=None, username=None, password=None, p
         raise ValueError('unworkable combination of authentication inputs')
 
     response = urlopen(request)
-    try:
-        pagination = get_pagination(response.headers['Link'])
-    except KeyError:
+    raw_link_header = response.headers.get('Link')
+    if raw_link_header is None:
         logging.debug('no Link header, nothing to paginate through.')
         pagination = Pagination(None, None, None, None)
+    pagination = get_pagination(raw_link_header)
 
     repos = json.loads(response.read())
     for r in repos:


### PR DESCRIPTION
In Python 2, `response.headers["header-key"]` would return a `KeyError` if the header wasn't present, but [in Python 3 it returns `None`](https://github.com/python/cpython/blob/3.11/Lib/email/message.py#L410-L419). [This](https://sprout-social.sentry.io/issues/5518469726/?project=4507391523422208&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=0) is currently the top source of errors in Sentry.