### PR TITLE
make btsearch.py work with sdm proxy

### DIFF
--- a/scripts/btgrep.py
+++ b/scripts/btgrep.py
@@ -1,49 +1,114 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""
+CLI wrapper around Sprout Social’s code‑search API.
+Communicates via StrongDM proxy.
+
+Usage
+
+# Through StrongDM proxy
+$ ./btsearch.py -i "BusPublisher"
+"""
 
 import argparse
 import json
+import os
 import sys
 import urllib.parse
 import urllib.request
+from typing import Optional
 
-# You need to fill in the domain of where you install
-# Botanist for this to work, obviously :)
-BOTANIST_DOMAIN = 'http://example.com'
-
-
-def get_vcs_prefix(vcs_loc):
-    if vcs_loc == 'bitbucket':
-        return 'bb'
-    elif vcs_loc == 'github':
-        return 'gh'
-    else:
-        raise ValueError('unknown vcs_loc: %s' % vcs_loc)
+SEARCH_ENDPOINT = "https://codesearcher.sproutsocial.sdm.network/search/results.json"
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument("PATTERN", help="regex pattern you wish to search for")
-    parser.add_argument("-i", "--ignore-case", help="Ignore case distinctions", action="store_true")
+def build_opener(proxy: Optional[str] = None) -> urllib.request.OpenerDirector:
+    """
+    Return an urllib opener that honours *proxy* (format HOST:PORT).
+    Falls back to no proxy if *proxy* is falsy.
+    """
+    if proxy:
+        if not proxy.startswith(("http://", "https://")):
+            proxy = "http://" + proxy  # urllib expects a scheme
+        handler = urllib.request.ProxyHandler({"http": proxy, "https": proxy})
+        return urllib.request.build_opener(handler)
+    return urllib.request.build_opener()
+
+
+def get_vcs_prefix(vcs_loc: str) -> str:
+    mapping = {"bitbucket": "bb", "github": "gh"}
+    try:
+        return mapping[vcs_loc]
+    except KeyError:
+        raise ValueError(f"unknown vcs_loc: {vcs_loc}")
+
+
+def as_text(obj) -> str:
+    """Convert bytes → str safely, leave str unchanged."""
+    return obj.decode("utf-8", errors="replace") if isinstance(obj, bytes) else str(obj)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Search Sprout Social’s code index and list the matches."
+    )
+    parser.add_argument("PATTERN", help="Regular expression to search for")
+    parser.add_argument(
+        "-i", "--ignore-case", help="Ignore case distinctions", action="store_true"
+    )
+    # parser.add_argument(
+        # "--proxy",
+        # metavar="HOST:PORT",
+        # help="Send the HTTP(S) request through the given proxy",
+    # )
     args = parser.parse_args()
 
-    params = urllib.parse.urlencode({'q': args.PATTERN, 'case': 'insensitive' if args.ignore_case else 'sensitive'})
-    r = urllib.request.urlopen(BOTANIST_DOMAIN + '/search/results.json?' + params).read()
-    data = json.loads(r).get('data', {}).get('results', {})
+    params = urllib.parse.urlencode(
+        {
+            "q": args.PATTERN,
+            "case": "insensitive" if args.ignore_case else "sensitive",
+        }
+    )
+    url = f"{SEARCH_ENDPOINT}?{params}"
 
-    if data is None:
-        print('no results found.')
+    # opener = build_opener(
+        # args.proxy
+        # or os.getenv("HTTP_PROXY")
+        # or os.getenv("http_proxy")
+        # or os.getenv("HTTPS_PROXY")
+        # or os.getenv("https_proxy")
+    # )
+    opener = build_opener("localhost:65230")
+
+    try:
+        with opener.open(url, timeout=30) as resp:
+            payload = resp.read()
+    except urllib.error.URLError as exc:
+        sys.stderr.write(f"error: request failed — {exc}\n")
+        sys.stderr.write("are you sure you're connected to StrongDM (sdm login && sdm connect --all) and the VPN?\n")
+        sys.exit(2)
+
+    # ...
+    results = json.loads(payload).get("data", {}).get("results") or {}
+    if not results:
+        print("no results found.")
         sys.exit(1)
 
-    for reponame in sorted(data.keys()):
-        for vcs_loc, repo_result_dict in data[reponame].items():
-            files = repo_result_dict['files']
-            for filename in sorted(files.keys()):
-                for srcline_obj in files[filename]:
-                    srcline = srcline_obj.get('srcline')
-                    if srcline is None:
-                        continue
-                    lineno = srcline_obj.get('lineno')
-                    if lineno is None:
-                        continue
+    for repo in sorted(results):
+        # strip leading "sproutsocial/" when present
+        repo_display = repo.split("/", 1)[1] if repo.startswith("sproutsocial/") else repo
 
-                    print('%s:%s:%s:%s:%s' % (get_vcs_prefix(vcs_loc), reponame.encode('utf-8'), filename.encode('utf-8'), lineno, srcline.encode('utf-8')))
+        for vcs_loc, repo_dict in results[repo].items():
+            for file in sorted(repo_dict.get("files", {})):
+                for hit in repo_dict["files"][file]:
+                    if (src := hit.get("srcline")) is None or (ln := hit.get("lineno")) is None:
+                        continue
+                    print(
+                        f"{get_vcs_prefix(vcs_loc)}:"
+                        f"{repo_display}:"
+                        f"{as_text(file)}:"
+                        f"{ln}:"
+                        f"{as_text(src).rstrip()}"
+                    )
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Botanist has a REST interface and a command line code search. It just needed a little love now that it's behind strongdm:

```
scripts/btgrep.py -i "new BusPublisher"
gh:bus:bus-admin/src/main/java/com/sproutsocial/bus/service/guice/BusAdminModule.java:113:        return new BusPublisher(systemDb.getWriteDataSource(), rawPublisher, config.getBusFactory().buildConfig());
gh:bus:bus-libs/bus-nsq/src/test/java/com/sproutsocial/bus/client/BusPublisherTest.java:36:        publisher = new BusPublisher(dataSource, rawPublisher, config);
gh:configuration-commons:configuration-commons-bus/src/main/java/com/sproutsocial/configuration/bus/BusFactory.java:122:            BusPublisher busPublisher = new BusPublisher(systemDb, rawPublisherManaged.get(), buildConfig());
gh:configuration-commons:configuration-commons-bus/src/main/java/com/sproutsocial/configuration/bus/BusFactory.java:123:            return new BusPublisherManaged(rawPublisherManaged, busPublisher);
gh:configuration-commons:configuration-commons-bus/src/main/java/com/sproutsocial/configuration/bus/BusFactory.java:478:            BusPublisher busPublisher = new BusPublisher(systemDb, rawPublisherManaged.get(), buildConfig());
...SNIP...
gh:unified-message-storage:ums-pipeline-utilities/src/test/java/com/sproutsocial/ums/pipeline/writers/bus/BusProtobufWriterTest.java:51:        publisher = new BusPublisher(mock(DataSource.class), rawPublisher, new Config());```